### PR TITLE
Adding in location for individual fields

### DIFF
--- a/tests/vertex_layout.rs
+++ b/tests/vertex_layout.rs
@@ -5,10 +5,15 @@ use wgpu_macros::VertexLayout;
 struct Vertex {
   #[layout(norm)]
   a: [u8; 2],
+  #[layout(location = 6)]
   #[layout(Float64)]
   b: [f32; 2],
   c: [u16; 2],
   d: f64,
+  #[layout(location = 10)]
+  e: u32,
+  f: u32,
+  g: f32,
 }
 
 #[test]
@@ -27,20 +32,47 @@ fn test() {
         wgpu::VertexAttribute {
           format: wgpu::VertexFormat::Float64,
           offset: wgpu::VertexFormat::Unorm8x2.size(),
-          shader_location: 1,
+          shader_location: 6,
         },
         wgpu::VertexAttribute {
           format: wgpu::VertexFormat::Uint16x2,
           offset: wgpu::VertexFormat::Unorm8x2.size()
             + wgpu::VertexFormat::Float64.size(),
-          shader_location: 2,
+          shader_location: 7,
         },
         wgpu::VertexAttribute {
           format: wgpu::VertexFormat::Float64,
           offset: wgpu::VertexFormat::Unorm8x2.size()
             + wgpu::VertexFormat::Float64.size()
             + wgpu::VertexFormat::Uint16x2.size(),
-          shader_location: 3,
+          shader_location: 8,
+        },
+        wgpu::VertexAttribute {
+          format: wgpu::VertexFormat::Uint32,
+          offset: wgpu::VertexFormat::Unorm8x2.size()
+            + wgpu::VertexFormat::Float64.size()
+            + wgpu::VertexFormat::Uint16x2.size()
+            + wgpu::VertexFormat::Float64.size(),
+          shader_location: 10,
+        },
+        wgpu::VertexAttribute {
+          format: wgpu::VertexFormat::Uint32,
+          offset: wgpu::VertexFormat::Unorm8x2.size()
+            + wgpu::VertexFormat::Float64.size()
+            + wgpu::VertexFormat::Uint16x2.size()
+            + wgpu::VertexFormat::Float64.size()
+            + wgpu::VertexFormat::Uint32.size(),
+          shader_location: 11,
+        },
+        wgpu::VertexAttribute {
+          format: wgpu::VertexFormat::Float32,
+          offset: wgpu::VertexFormat::Unorm8x2.size()
+            + wgpu::VertexFormat::Float64.size()
+            + wgpu::VertexFormat::Uint16x2.size()
+            + wgpu::VertexFormat::Float64.size()
+            + wgpu::VertexFormat::Uint32.size()
+            + wgpu::VertexFormat::Uint32.size(),
+          shader_location: 12,
         },
       ],
     }


### PR DESCRIPTION
When using multiple vertex buffers, you need to manually specify the shader `location` so that way they don't overlap.

This PR makes that possible:

```rust
#[repr(C)]
#[derive(VertexLayout)]
struct VertexBuffer1 {
    position: [f32; 3],
}

#[repr(C)]
#[derive(VertexLayout)]
struct VertexBuffer2 {
    #[layout(location = 1)]
    tex_coords: [u8; 2],
}
```